### PR TITLE
update dal_parametric.blocks_per_epoch

### DIFF
--- a/networks/weeklynet/values.yaml
+++ b/networks/weeklynet/values.yaml
@@ -88,7 +88,7 @@ activation:
       slot_size: 65536
       redundancy_factor: 16
       page_size: 4096
-      blocks_per_epoch: 32
+      blocks_per_epoch: 1
     smart_rollup_private_enable: true
     smart_rollup_riscv_pvm_enable: true
     smart_rollup_origination_size: 6314


### PR DESCRIPTION
`blocks_per_epoch` is 1 in Oxford and Alpha, this value is outdated.