### PR TITLE
activate AI on weeklynet

### DIFF
--- a/networks/weeklynet/values.yaml
+++ b/networks/weeklynet/values.yaml
@@ -27,7 +27,7 @@ activation:
     minimal_stake: '6000000000'
     minimal_frozen_stake: '600000000'
     adaptive_issuance_launch_ema_threshold: 10000000
-    adaptive_issuance_activation_vote_enable: false
+    adaptive_issuance_activation_vote_enable: true
     autostaking_enable: true
     global_limit_of_staking_over_baking: 5
     edge_of_staking_over_delegation: 2


### PR DESCRIPTION
There is a new "force enable" parameter in proto alpha but it can not be used on weeklynet because the parameter is not available in oxford, which is weeklynet's starting proto.

An alternative is to enable the vote, set the threshold to 5% and have the teztnets baker vote yes. This way, AI will be active ~ 8 cycles after chain activation.

This is how we were doing for oxford 1, so the threshold is already set to 5% and the baker is already configured to vote yes.