### PR TITLE
provisional network_stakes setting

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -266,6 +266,7 @@ const parisnet_chain = new TezosChain(
     rpcUrls: [],
     indexers: [],
     chartRepoVersion: "7.1.2",
+    networkStakes: true,
   },
   provider
 )
@@ -407,6 +408,7 @@ function getTeztnets(chains: TezosChain[]): object {
       rpc_urls: chain.getRpcUrls(),
       masked_from_main_page: false,
       indexers: chain.params.indexers || [],
+      network_stakes: chain.params.networkStakes || false
     }
     if (Object.keys(chain.dalNodes).length > 0) {
       teztnets[chain.name].dal_nodes = chain.dalNodes;

--- a/tezos/chain.ts
+++ b/tezos/chain.ts
@@ -21,6 +21,7 @@ export interface TezosParameters {
   readonly rpcUrls?: string[]
   readonly helmValuesFile: string
   readonly schedule?: string
+  readonly networkStakes?: boolean
 }
 
 const gcpRegion = "us-central1";


### PR DESCRIPTION
**Requires local testing with Jekyll!**

Steps:
1. Run `pulumi up` to set `network_stakes` to `true` or `false` for every network.
2. Run `local_web_serve.sh` and check pages.

There should be a `network_stakes` values set in `teztnets.json` which get passed into the `teztnets_xyz_page/teztnet_page.md.jinja2` template.