### PR TITLE
weeklynet: update value of dal_attested_slots_validity_lag

### DIFF
--- a/networks/weeklynet/values.yaml
+++ b/networks/weeklynet/values.yaml
@@ -117,7 +117,7 @@ activation:
       metadata: 0
       dal_page: 1
       dal_parameters: 1
-      dal_attested_slots_validity_lag: 241920
+      dal_attested_slots_validity_lag: 80
     vdf_difficulty: '10000000'
     zk_rollup_enable: true
     zk_rollup_origination_size: 4000


### PR DESCRIPTION
Make `dal_attested_slots_validity_lag` 2 times  `smart_rollup_challenge_window_in_blocks` because `challange_window` on `mainnet` is for 2 weeks, and the dal_validity_lag` is for 4 weeks.

This will be needed once https://gitlab.com/tezos/tezos/-/merge_requests/14158 is merged.