### PR TITLE
Chain: Add bootstrap DAL nodes maintained by the core-devs

### DIFF
--- a/tezos/chain.ts
+++ b/tezos/chain.ts
@@ -341,6 +341,7 @@ export class TezosChain extends pulumi.ComponentResource {
       // Set bootstrap peers on the network config (specific to testnets)
       this.tezosHelmValues.node_config_network.dal_config.bootstrap_peers = [
         `dal.${name}.${domainName}:11732`
+        `${name}.bootstrap.dal.nomadic-labs.com`
       ];
     }
 


### PR DESCRIPTION
This commit introduces a domain for a bootstrap DAL node, which will be provisioned by the DAL team.

This enhancement will improve the resilience of the DAL network on test networks and assist the DAL team in monitoring and detecting potential issues more effectively.