### PR TITLE
new TezosChain rpcBlockDangerous parameter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -156,6 +156,7 @@ const bakingnet_chain = new TezosChain(
     indexers: [],
     chartRepoVersion: "8.0.3",
     networkStakes: true,
+    rpcBlockDangerous: true,
   },
   provider
 )
@@ -252,7 +253,7 @@ new TezosFaucet(
 */
 // END of Nextnet
 
-// Tallinnnet test network 
+// Tallinnnet test network
 //
 const tallinnnet_chain = new TezosChain(
   {
@@ -487,7 +488,7 @@ const ghostnetTeztnet = {
   docker_build: `tezos/tezos:${ghostnetRollingVersion}`,
   faucet_url: ``,
   snapshot_url: `https://snapshots.tzinit.org/ghostnet/rolling`,
-  faucet: false,  
+  faucet: false,
   snapshot: false,
   git_ref: ghostnetRollingVersion,
   human_name: "Ghostnet",

--- a/tezos/chain.ts
+++ b/tezos/chain.ts
@@ -24,6 +24,7 @@ export interface TezosParameters {
   readonly helmValuesFile: string
   readonly schedule?: string
   readonly networkStakes?: boolean
+  readonly rpcBlockDangerous?: boolean
 }
 
 const gcpRegion = "us-central1";
@@ -114,10 +115,10 @@ export class TezosChain extends pulumi.ComponentResource {
         pulumi
           .output(imageResolver.getLatestTagAsync(deployDate))
           .apply((tag) => `${imageResolver.image}:${tag}`)
-      // Hack XXX 
+      // Hack XXX
       // This is a trick to change Weeklynet's name when it
-      // needs to be respun. if the chain has already launched but 
-      // gets bricked because it can no longer upgrade from one proto to the 
+      // needs to be respun. if the chain has already launched but
+      // gets bricked because it can no longer upgrade from one proto to the
       // next, change the date below. It will start with a different chainId.
       // This way, it won't mix with the existing Weeklynet and will be able to sync.
       // Otherwise, the old broken Weeklynet will mix with the new one and you'll never be able to produce
@@ -166,6 +167,23 @@ export class TezosChain extends pulumi.ComponentResource {
     // RPC Ingress
     const rpcDomain = `rpc.${name}.${domainName}`
 
+    // ingress settings
+    const rpcAnnotations: Record<string, string> = {
+      "kubernetes.io/ingress.class": "nginx",
+      "cert-manager.io/cluster-issuer": "letsencrypt-prod",
+      "nginx.ingress.kubernetes.io/enable-cors": "true",
+      "nginx.ingress.kubernetes.io/cors-allow-origin": "*",
+    }
+
+    // block dangerous RPC calls
+    if (params.rpcBlockDangerous) {
+      rpcAnnotations["nginx.ingress.kubernetes.io/server-snippet"] = `# block dangerous RPC calls
+location ~ ^/(config|network) {
+  deny all;
+  return 403;
+}`
+    }
+
     const rpcIngName = `${rpcDomain}-ingress`
     new k8s.networking.v1.Ingress(
       rpcIngName,
@@ -173,12 +191,7 @@ export class TezosChain extends pulumi.ComponentResource {
         metadata: {
           namespace: this.namespace.metadata.name,
           name: rpcIngName,
-          annotations: {
-            "kubernetes.io/ingress.class": "nginx",
-            "cert-manager.io/cluster-issuer": "letsencrypt-prod",
-            "nginx.ingress.kubernetes.io/enable-cors": "true",
-            "nginx.ingress.kubernetes.io/cors-allow-origin": "*",
-          },
+          annotations: rpcAnnotations,
           labels: { app: "tezos-node" },
         },
         spec: {
@@ -225,12 +238,7 @@ export class TezosChain extends pulumi.ComponentResource {
           metadata: {
             namespace: this.namespace.metadata.name,
             name: aliasRpcIngName,
-            annotations: {
-              "kubernetes.io/ingress.class": "nginx",
-              "cert-manager.io/cluster-issuer": "letsencrypt-prod",
-              "nginx.ingress.kubernetes.io/enable-cors": "true",
-              "nginx.ingress.kubernetes.io/cors-allow-origin": "*",
-            },
+            annotations: rpcAnnotations,
             labels: { app: "tezos-node" },
           },
           spec: {


### PR DESCRIPTION
`rpcBlockDangerous` (true/false) parameter for `TezosChain` that blocks potentially dangerous `/config*` and `/network*` RPC calls.

To use, add `rpcBlockDangerous: true,` to the `TezosChain` object constructor, e.g.

```ts
const bakingnet_chain = new TezosChain(
  {
    category: longCategory,
    humanName: "Bakingnet",
    // more params...
    rpcBlockDangerous: true,
  },
  provider
)
```

The RPC block is applied to `Bakingnet` only at this time.